### PR TITLE
[FEATURE#19954] Adaptation aux routes sur conversation

### DIFF
--- a/src/ConversationManager.php
+++ b/src/ConversationManager.php
@@ -28,7 +28,7 @@ class ConversationManager
         $response = $this->fireRequest($request, $this->app["cookies.authenticator"]);
 
         $conversations_array = [];
-        $conversations       = $response["conversations"]["hits"];
+        $conversations       = $response["hits"];
         foreach ($conversations as $conversation) {
             $conversation_item = new Conversation();
             $conversation_item->fromArray($conversation);


### PR DESCRIPTION
- Le `findByQueryString` retourne maintenant le bon champ de la response
 - Ajout des routes `/search` et `/stats` dans le `DumbMethodsProxy`