### PR TITLE
[FEATURE#29151] Rajout de la propriété last_message

### DIFF
--- a/src/Conversation.php
+++ b/src/Conversation.php
@@ -28,6 +28,9 @@ class Conversation implements \JsonSerializable
     /* @var array $messages */
     private $messages;
 
+    /* @var array $last_message */
+    private $last_message;
+
     /* @var array $save_actions */
     private $save_actions;
 
@@ -256,6 +259,28 @@ class Conversation implements \JsonSerializable
     }
 
     /**
+     * Set conversation's last message
+     *
+     * @return array
+     */
+    public function setLastMessage()
+    {
+        $this->last_message = end($this->messages);
+
+        return $this;
+    }
+
+    /**
+     * Get conversation's last message
+     *
+     * @return array
+     */
+    public function getLastMessage()
+    {
+        return $this->last_message;
+    }
+
+    /**
      * Fills itself from array
      *
      * @param  array  $conversation
@@ -282,14 +307,15 @@ class Conversation implements \JsonSerializable
     public function toArray()
     {
         return [
-            "id"         => $this->getId(),
-            "title"      => $this->getTitle(),
-            "metas"      => $this->getMetas(),
-            "acls"       => $this->getAcls(),
-            "messages"   => $this->getMessages(),
-            "created_at" => $this->getCreatedAt("c"),
-            "updated_at" => $this->getUpdatedAt("c"),
-            "deleted_at" => $this->getDeletedAt("c"),
+            "id"           => $this->getId(),
+            "title"        => $this->getTitle(),
+            "metas"        => $this->getMetas(),
+            "acls"         => $this->getAcls(),
+            "messages"     => $this->getMessages(),
+            "last_message" => $this->getLastMessage(),
+            "created_at"   => $this->getCreatedAt("c"),
+            "updated_at"   => $this->getUpdatedAt("c"),
+            "deleted_at"   => $this->getDeletedAt("c"),
         ];
     }
 

--- a/src/Conversation.php
+++ b/src/Conversation.php
@@ -245,6 +245,8 @@ class Conversation implements \JsonSerializable
             )
         );
 
+        $this->last_message = end($this->messages[]);
+
         return $this;
     }
 
@@ -256,18 +258,6 @@ class Conversation implements \JsonSerializable
     public function getMessages()
     {
         return $this->messages;
-    }
-
-    /**
-     * Set conversation's last message
-     *
-     * @return array
-     */
-    public function setLastMessage()
-    {
-        $this->last_message = end($this->messages);
-
-        return $this;
     }
 
     /**


### PR DESCRIPTION
- Il faut ajouter `last_message` sinon le proxy ne nous renvoit pas cette propriété