### PR TITLE
[FEATURE#53902] ajout de sort optionnel proxy v2

### DIFF
--- a/src/ConversationManager.php
+++ b/src/ConversationManager.php
@@ -21,10 +21,10 @@ class ConversationManager
         $this->app = $app;
     }
 
-    public function findByQueryString($query, $from = 0, $size = 99999)
+    public function findByQueryString($query, $from = 0, $size = 99999, $sort = "")
     {
         $query    = urlencode($query);
-        $response = $this->fireRequest("GET", "/search?q={$query}&from={$from}&size={$size}");
+        $response = $this->fireRequest("GET", "/search?q={$query}&from={$from}&size={$size}&sort={$sort}");
 
         $response["hits"] = array_map(
             function ($hit) {


### PR DESCRIPTION
La route /search de conversation-api accepte un sort optionnel mais il n'est pas présent dans le proxy. V2